### PR TITLE
Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,19 @@ Based on the MIT-licensed [Cinder-DMXUsbPro](https://github.com/q-depot/Cinder-D
 
 ## What it does
 
-The Enttec device receives commands over serial and translates them into a stream of DMX commands for your lighting hardware.
+The Enttec hardware receives commands over serial and translates them into a stream of DMX commands for your lighting hardware.
 
-This library simplifies connecting to and sending commands to the Enttec device. Regular DMX packet delivery is handled on a secondary thread, with a threadsafe `bufferData` method for providing complete information packets. Querying and setting the DMX hardware’s basic parameters is also supported.
+This library eases connecting to and sending commands to the Enttec hardware.
 
-Have a look at the DMXBasicApp sample to get an idea for how to use the block.
+Using the block requires three steps:
+
+1. Connect to a physical device by constructing a `dmx::EnttecDevice`.
+2. Start the virtual device’s data loop `device->startLoop()`.
+3. Pass buffers of data to your virtual device `device->bufferData(buffer)`.
+
+Have a look at the DMXBasicApp sample to see these commands in context. Note that it will run even if you aren’t able to connect to a device.
+
+Serial message delivery is handled on a secondary thread, with the `bufferData` method providing a threadsafe interface to update the data sent to the DMX controller. Querying the DMX hardware’s basic parameters is also supported (though responses from the device occasionally stall). We can attempt to set the hardware’s parameters, but sending a message matching the device documentation doesn’t appear to work. We may try adjusting that message in the future.
 
 ## What is DMX
 

--- a/src/dmx/EnttecDevice.cpp
+++ b/src/dmx/EnttecDevice.cpp
@@ -187,7 +187,7 @@ std::future<EnttecDevice::Settings> EnttecDevice::loadSettings() const {
 			}
 
 			const auto message_body_start = 4; // start, type, data lsb, data msb
-			// skip two bytes (lsb, msb of message size)
+			// skip two bytes (lsb, msb of message size, it seems)
 			const auto firmware_index_lsb = message_body_start;
 			const auto firmware_index_msb = message_body_start + 1;
 			const auto break_time_index = message_body_start + 2;
@@ -215,6 +215,9 @@ void EnttecDevice::writeData()
 	std::lock_guard<std::mutex> lock(_data_mutex);
 
 	if (_serial) {
+		// May need to include 2 or 3 more bytes in data size so it represents complete message size. (label, lsb, msb)
+		// The documentation suggests otherwise, but the Mk2 sends back undocumented bytes when querying settings.
+		// If we seem to be missing the last handful of channels of data when testing the full 512 channels, this could be why.
 		const auto data_size = _message_body.size() + 1; // account for data start code
 		const auto header = std::array<uint8_t, 5> {
 			StartOfMessage,


### PR DESCRIPTION
Improved usage notes in README.
Notes on data buffer size specification in implementation file.

The number of bytes we tell the device are contained in our message may be the complete message size, not just the size of the user data in the message. If that is the case, the last few channels of DMX won't be receiving data (something we should be able to see in a 512 channel setup). This will be easy to fix if it proves to be a problem.
